### PR TITLE
Add onResume

### DIFF
--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -209,7 +209,7 @@ public class MainActivity extends Activity {
         webView.evaluateJavascript("(function() { return document.querySelectorAll('x-peer[transfer]').length > 0; })();", new ValueCallback<String>() {
             @Override
             public void onReceiveValue(String t) {
-                if (!parseBoolean(t) || (pulled && forceRefresh)) {
+                if (!Boolean.valueOf(t) || (pulled && forceRefresh)) {
                     //currently no transfer OR forceRefresh by pullingToRefresh twice
                     webView.loadUrl(baseURL);
                     forceRefresh = false;

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -71,6 +71,7 @@ public class MainActivity extends Activity {
     private boolean loadAgain = true; // workaround cause Snapdrop website does not show the correct devices after first load
     private boolean currentlyOffline = true;
     private boolean currentlyLoading = false;
+    private boolean forceRefresh = false;
 
     public boolean onlyText = false;
     public List<Pair<String, String>> downloadFilesList = new ArrayList<>(); // name - size
@@ -191,7 +192,7 @@ public class MainActivity extends Activity {
         new UpdateChecker().execute("");
     }
 
-    private void refreshWebsite(boolean pulled) {
+    private void refreshWebsite(final boolean pulled) {
         if (isInternetAvailable()) {
             isTranfering(pulled);
         } else {
@@ -203,12 +204,10 @@ public class MainActivity extends Activity {
         refreshWebsite(false);
     }
     
-    private boolean forceRefresh = false;
-    
-    private void isTranfering(Boolean pulled) {
+    private void isTranfering(final Boolean pulled) {
         webView.evaluateJavascript("(function() { return document.querySelectorAll('x-peer[transfer]').length > 0; })();", new ValueCallback<String>() {
             @Override
-            public void onReceiveValue(String t) {
+            public void onReceiveValue(final String t) {
                 if (!Boolean.valueOf(t) || (pulled && forceRefresh)) {
                     //currently no transfer OR forceRefresh by pullingToRefresh twice
                     webView.loadUrl(baseURL);

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -275,6 +275,12 @@ public class MainActivity extends Activity {
             super.onBackPressed();
         }
     }
+    
+    @Override
+    public void onResume() {
+        super.onResume();
+        refreshWebsite();
+    }
 
     @Override
     protected void onDestroy() {

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -206,7 +206,7 @@ public class MainActivity extends Activity {
     private boolean forceRefresh = false;
     
     private void isTranfering(Boolean pulled) {
-        webview.evaluateJavascript("(function() { return document.querySelectorAll('x-peer[transfer]').length > 0; })();", new ValueCallback<Boolean>() {
+        webView.evaluateJavascript("(function() { return document.querySelectorAll('x-peer[transfer]').length > 0; })();", new ValueCallback<Boolean>() {
             @Override
             public void onReceiveValue(Boolean t) {
                 if (!t || (pulled && forceRefresh)) {

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -206,10 +206,10 @@ public class MainActivity extends Activity {
     private boolean forceRefresh = false;
     
     private void isTranfering(Boolean pulled) {
-        webView.evaluateJavascript("(function() { return document.querySelectorAll('x-peer[transfer]').length > 0; })();", new ValueCallback<Boolean>() {
+        webView.evaluateJavascript("(function() { return document.querySelectorAll('x-peer[transfer]').length > 0; })();", new ValueCallback<String>() {
             @Override
-            public void onReceiveValue(Boolean t) {
-                if (!t || (pulled && forceRefresh)) {
+            public void onReceiveValue(String t) {
+                if (!parseBoolean(t) || (pulled && forceRefresh)) {
                     //currently no transfer OR forceRefresh by pullingToRefresh twice
                     webView.loadUrl(baseURL);
                     forceRefresh = false;


### PR DESCRIPTION
refresh website in onresume, because some times the app is open and your phone gets locked and somehow (i guess battery saving) snapdrop is stopped in the app (phone disappears from desktop snapdrop) but if you unlock the phone again, the desktop device is still displayed in the app and you have to pull to refresh, this should be fixed now (hope this was comprehensible)