### PR TITLE
Remove custom Snapdrop-Fork

### DIFF
--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -236,7 +236,7 @@ public class JavaScriptInterface {
                 "   Events.fire('notify-user', 'Copied to clipboard');"+
                 "}"+
                 //change tweet link
-                "document.querySelector('.icon-button[title~="Tweet"]').href = 'https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20An%20Android%20client%20for https://snapdrop.net%20by%20@robin_linus%20&';"+
+                "document.querySelector('.icon-button[title~='Tweet']').href = 'https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20An%20Android%20client%20for https://snapdrop.net%20by%20@robin_linus%20&';"+
             
                 //add settings icon-button
                 "let settingsIconButton = document.createElement('a');"+

--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -285,7 +285,7 @@ public class JavaScriptInterface {
                 "PeerUI.prototype._onTouchEnd = function(e){" +
                 "               this._oTE(e);" +
                 "               if ((Date.now() - this._touchStart < 500) && SnapdropAndroid.shouldOpenSendTextDialog()) {" +
-                "                   Events.fire('text-recipient', e.detail);" +
+                "                   Events.fire('text-recipient', this._peer.id);" +
                 "               }" +
                 "            };" +
             

--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -234,7 +234,7 @@ public class JavaScriptInterface {
                 "ReceiveTextDialog.prototype._onCopy = function(){" +
                 "   SnapdropAndroid.copyToClipboard(this.$text.textContent);" +
                 "   Events.fire('notify-user', 'Copied to clipboard');" +
-                "}"+
+                "}" +
                 //change tweet link
                 "document.querySelector('.icon-button[title~='Tweet']').href = 'https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20An%20Android%20client%20for https://snapdrop.net%20by%20@robin_linus%20&';" +
             

--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -230,11 +230,19 @@ public class JavaScriptInterface {
     }
     public static String initialiseWebsite() {
         return "javascript: " +
-                //change onCopy to connect to JavaScriptInterface
+                //change ReceiveTextDialog._onCopy to connect to JavaScriptInterface
+                "ReceiveTextDialog.prototype._oC = ReceiveTextDialog.prototype._onCopy;" +
                 "ReceiveTextDialog.prototype._onCopy = function(){" +
-                "   SnapdropAndroid.copyToClipboard(this.$text.textContent);" +
-                "   Events.fire('notify-user', 'Copied to clipboard');" +
-                "}" +
+                "               this._oC();" +
+                "               SnapdropAndroid.copyToClipboard(this.$text.textContent);" +
+                "            };" +
+                //change PeerUI.setProgress to connect to JavaScriptInterface
+                "PeerUI.prototype.sP = PeerUI.prototype.setProgress;" +
+                "PeerUI.prototype.setProgress = function(progress){" +
+                "               SnapdropAndroid.setProgress(progress);" +
+                "               this.sP(progress);" +
+                "            };" +
+            
                 //change tweet link
                 "document.querySelector('.icon-button[title~='Tweet']').href = 'https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20An%20Android%20client%20for https://snapdrop.net%20by%20@robin_linus%20&';" +
             

--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -230,6 +230,33 @@ public class JavaScriptInterface {
     }
     public static String initialiseWebsite() {
         return "javascript: " +
+                //change onCopy to connect to JavaScriptInterface
+                "ReceiveTextDialog.prototype._onCopy = function(){"+
+                "   SnapdropAndroid.copyToClipboard(this.$text.textContent);"+
+                "   Events.fire('notify-user', 'Copied to clipboard');"+
+                "}"+
+                //change tweet link
+                "document.querySelector('.icon-button[title~="Tweet"]').href = 'https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20An%20Android%20client%20for https://snapdrop.net%20by%20@robin_linus%20&';"+
+            
+                //add settings icon-button
+                "let settingsIconButton = document.createElement('a');"+
+                "settingsIconButton.className = 'icon-button';"+
+                "settingsIconButton.target = '_blank';"+
+                "settingsIconButton.href = 'update.html#settings';"+
+                "settingsIconButton.title = 'App Settings';"+
+                "settingsIconButton.rel = 'noreferrer';"+
+
+                "let settingsSvg = document.createElementNS('http://www.w3.org/2000/svg','svg');"+
+                "settingsSvg.setAttribute('class', 'icon');"+
+
+                "let settingsPath = document.createElementNS('http://www.w3.org/2000/svg','path');"+
+                "settingsPath.setAttribute('d', 'M19.43 12.98c.04-.32.07-.64.07-.98 0-.34-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46c-.09-.16-.26-.25-.44-.25-.06 0-.12.01-.17.03l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65C14.46 2.18 14.25 2 14 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.06-.02-.12-.03-.18-.03-.17 0-.34.09-.43.25l-2 3.46c-.13.22-.07.49.12.64l2.11 1.65c-.04.32-.07.65-.07.98 0 .33.03.66.07.98l-2.11 1.65c-.19.15-.24.42-.12.64l2 3.46c.09.16.26.25.44.25.06 0 .12-.01.17-.03l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1c.06.02.12.03.18.03.17 0 .34-.09.43-.25l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.65zm-1.98-1.71c.04.31.05.52.05.73 0 .21-.02.43-.05.73l-.14 1.13.89.7 1.08.84-.7 1.21-1.27-.51-1.04-.42-.9.68c-.43.32-.84.56-1.25.73l-1.06.43-.16 1.13-.2 1.35h-1.4l-.19-1.35-.16-1.13-1.06-.43c-.43-.18-.83-.41-1.23-.71l-.91-.7-1.06.43-1.27.51-.7-1.21 1.08-.84.89-.7-.14-1.13c-.03-.31-.05-.54-.05-.74s.02-.43.05-.73l.14-1.13-.89-.7-1.08-.84.7-1.21 1.27.51 1.04.42.9-.68c.43-.32.84-.56 1.25-.73l1.06-.43.16-1.13.2-1.35h1.39l.19 1.35.16 1.13 1.06.43c.43.18.83.41 1.23.71l.91.7 1.06-.43 1.27-.51.7 1.21-1.07.85-.89.7.14 1.13zM12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 6c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z');"+
+                "settingsSvg.appendChild(settingsPath);"+
+                "settingsIconButton.appendChild(settingsSvg);"+
+
+                "let aboutIconButton = document.querySelector('.icon-button[href='#about']');"+
+                "aboutIconButton.parentElement.insertBefore(settingsIconButton, aboutIconButton.nextSibling);"+
+            
                 "window.addEventListener('file-received', e => {" +
                 "   SnapdropAndroid.saveDownloadFileName(e.detail.name, e.detail.size);" +
                 "}, false);" +

--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -231,31 +231,31 @@ public class JavaScriptInterface {
     public static String initialiseWebsite() {
         return "javascript: " +
                 //change onCopy to connect to JavaScriptInterface
-                "ReceiveTextDialog.prototype._onCopy = function(){"+
-                "   SnapdropAndroid.copyToClipboard(this.$text.textContent);"+
-                "   Events.fire('notify-user', 'Copied to clipboard');"+
+                "ReceiveTextDialog.prototype._onCopy = function(){" +
+                "   SnapdropAndroid.copyToClipboard(this.$text.textContent);" +
+                "   Events.fire('notify-user', 'Copied to clipboard');" +
                 "}"+
                 //change tweet link
-                "document.querySelector('.icon-button[title~='Tweet']').href = 'https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20An%20Android%20client%20for https://snapdrop.net%20by%20@robin_linus%20&';"+
+                "document.querySelector('.icon-button[title~='Tweet']').href = 'https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20An%20Android%20client%20for https://snapdrop.net%20by%20@robin_linus%20&';" +
             
                 //add settings icon-button
-                "let settingsIconButton = document.createElement('a');"+
-                "settingsIconButton.className = 'icon-button';"+
-                "settingsIconButton.target = '_blank';"+
-                "settingsIconButton.href = 'update.html#settings';"+
-                "settingsIconButton.title = 'App Settings';"+
-                "settingsIconButton.rel = 'noreferrer';"+
+                "let settingsIconButton = document.createElement('a');" +
+                "settingsIconButton.className = 'icon-button';" +
+                "settingsIconButton.target = '_blank';" +
+                "settingsIconButton.href = 'update.html#settings';" +
+                "settingsIconButton.title = 'App Settings';" +
+                "settingsIconButton.rel = 'noreferrer';" +
 
-                "let settingsSvg = document.createElementNS('http://www.w3.org/2000/svg','svg');"+
-                "settingsSvg.setAttribute('class', 'icon');"+
+                "let settingsSvg = document.createElementNS('http://www.w3.org/2000/svg','svg');" +
+                "settingsSvg.setAttribute('class', 'icon');" +
 
-                "let settingsPath = document.createElementNS('http://www.w3.org/2000/svg','path');"+
-                "settingsPath.setAttribute('d', 'M19.43 12.98c.04-.32.07-.64.07-.98 0-.34-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46c-.09-.16-.26-.25-.44-.25-.06 0-.12.01-.17.03l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65C14.46 2.18 14.25 2 14 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.06-.02-.12-.03-.18-.03-.17 0-.34.09-.43.25l-2 3.46c-.13.22-.07.49.12.64l2.11 1.65c-.04.32-.07.65-.07.98 0 .33.03.66.07.98l-2.11 1.65c-.19.15-.24.42-.12.64l2 3.46c.09.16.26.25.44.25.06 0 .12-.01.17-.03l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1c.06.02.12.03.18.03.17 0 .34-.09.43-.25l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.65zm-1.98-1.71c.04.31.05.52.05.73 0 .21-.02.43-.05.73l-.14 1.13.89.7 1.08.84-.7 1.21-1.27-.51-1.04-.42-.9.68c-.43.32-.84.56-1.25.73l-1.06.43-.16 1.13-.2 1.35h-1.4l-.19-1.35-.16-1.13-1.06-.43c-.43-.18-.83-.41-1.23-.71l-.91-.7-1.06.43-1.27.51-.7-1.21 1.08-.84.89-.7-.14-1.13c-.03-.31-.05-.54-.05-.74s.02-.43.05-.73l.14-1.13-.89-.7-1.08-.84.7-1.21 1.27.51 1.04.42.9-.68c.43-.32.84-.56 1.25-.73l1.06-.43.16-1.13.2-1.35h1.39l.19 1.35.16 1.13 1.06.43c.43.18.83.41 1.23.71l.91.7 1.06-.43 1.27-.51.7 1.21-1.07.85-.89.7.14 1.13zM12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 6c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z');"+
-                "settingsSvg.appendChild(settingsPath);"+
-                "settingsIconButton.appendChild(settingsSvg);"+
+                "let settingsPath = document.createElementNS('http://www.w3.org/2000/svg','path');" +
+                "settingsPath.setAttribute('d', 'M19.43 12.98c.04-.32.07-.64.07-.98 0-.34-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46c-.09-.16-.26-.25-.44-.25-.06 0-.12.01-.17.03l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65C14.46 2.18 14.25 2 14 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.06-.02-.12-.03-.18-.03-.17 0-.34.09-.43.25l-2 3.46c-.13.22-.07.49.12.64l2.11 1.65c-.04.32-.07.65-.07.98 0 .33.03.66.07.98l-2.11 1.65c-.19.15-.24.42-.12.64l2 3.46c.09.16.26.25.44.25.06 0 .12-.01.17-.03l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1c.06.02.12.03.18.03.17 0 .34-.09.43-.25l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.65zm-1.98-1.71c.04.31.05.52.05.73 0 .21-.02.43-.05.73l-.14 1.13.89.7 1.08.84-.7 1.21-1.27-.51-1.04-.42-.9.68c-.43.32-.84.56-1.25.73l-1.06.43-.16 1.13-.2 1.35h-1.4l-.19-1.35-.16-1.13-1.06-.43c-.43-.18-.83-.41-1.23-.71l-.91-.7-1.06.43-1.27.51-.7-1.21 1.08-.84.89-.7-.14-1.13c-.03-.31-.05-.54-.05-.74s.02-.43.05-.73l.14-1.13-.89-.7-1.08-.84.7-1.21 1.27.51 1.04.42.9-.68c.43-.32.84-.56 1.25-.73l1.06-.43.16-1.13.2-1.35h1.39l.19 1.35.16 1.13 1.06.43c.43.18.83.41 1.23.71l.91.7 1.06-.43 1.27-.51.7 1.21-1.07.85-.89.7.14 1.13zM12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm0 6c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z');" +
+                "settingsSvg.appendChild(settingsPath);" +
+                "settingsIconButton.appendChild(settingsSvg);" +
 
-                "let aboutIconButton = document.querySelector('.icon-button[href='#about']');"+
-                "aboutIconButton.parentElement.insertBefore(settingsIconButton, aboutIconButton.nextSibling);"+
+                "let aboutIconButton = document.querySelector('.icon-button[href='#about']');" +
+                "aboutIconButton.parentElement.insertBefore(settingsIconButton, aboutIconButton.nextSibling);" +
             
                 "window.addEventListener('file-received', e => {" +
                 "   SnapdropAndroid.saveDownloadFileName(e.detail.name, e.detail.size);" +

--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -327,6 +327,7 @@ public class JavaScriptInterface {
             context.transfer = true;
         } else {
             context.transfer = false;
+            context.forceRefresh = false; //reset forceRefresh after transfer finished so pullToRefresh doesn't unexpectedly force refreshes by "first time"
         }
     }
 

--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -265,6 +265,12 @@ public class JavaScriptInterface {
                 "let aboutIconButton = document.querySelector('.icon-button[href=\"#about\"]');" +
                 "aboutIconButton.parentElement.insertBefore(settingsIconButton, aboutIconButton.nextSibling);" +
             
+                //remove donation button (play guidelines)
+                "document.querySelector('.icon-button[href*=\"paypal\"]').hidden = true;" +
+            
+                //remove "safari hack"                 
+                "document.body.onclick = null;" +
+            
                 //change ServerConnection.send(message) to connect to JavaScriptInterface
                 "ServerConnection.prototype.s = ServerConnection.prototype.send;" +
                 "ServerConnection.prototype.send = function(message){" +

--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -236,7 +236,7 @@ public class JavaScriptInterface {
                 "               this._oC();" +
                 "               SnapdropAndroid.copyToClipboard(this.$text.textContent);" +
                 "            };" +
-                //change PeerUI.setProgress to connect to JavaScriptInterface
+                //change PeerUI.setProgress(progress) to connect to JavaScriptInterface
                 "PeerUI.prototype.sP = PeerUI.prototype.setProgress;" +
                 "PeerUI.prototype.setProgress = function(progress){" +
                 "               SnapdropAndroid.setProgress(progress);" +
@@ -265,18 +265,26 @@ public class JavaScriptInterface {
                 "let aboutIconButton = document.querySelector('.icon-button[href='#about']');" +
                 "aboutIconButton.parentElement.insertBefore(settingsIconButton, aboutIconButton.nextSibling);" +
             
+                //change ServerConnection.send(message) to connect to JavaScriptInterface
+                "ServerConnection.prototype.s = ServerConnection.prototype.send;" +
+                "ServerConnection.prototype.send = function(message){" +
+                "               this.s(message);" +
+                "               if (message.type == 'pong') {" +
+                "                   SnapdropAndroid.updateLastOnlineTime();" +
+                "               }" +
+                "            };" +
+                
+                //change PeerUI._onTouchEnd(e) to connect to JavaScriptInterface
+                "PeerUI.prototype._oTE = PeerUI.prototype._onTouchEnd;" +
+                "PeerUI.prototype._onTouchEnd = function(e){" +
+                "               this._oTE(e);" +
+                "               if ((Date.now() - this._touchStart < 500) && SnapdropAndroid.shouldOpenSendTextDialog()) {" +
+                "                   Events.fire('text-recipient', e.detail);" +
+                "               }" +
+                "            };" +
+            
                 "window.addEventListener('file-received', e => {" +
                 "   SnapdropAndroid.saveDownloadFileName(e.detail.name, e.detail.size);" +
-                "}, false);" +
-
-                "window.addEventListener('serverconnection-active', e => {" +
-                "   SnapdropAndroid.updateLastOnlineTime();" +
-                "}, false);" +
-
-                "window.addEventListener('recipient-shortclicked', e => {" +
-                "   if (SnapdropAndroid.shouldOpenSendTextDialog()) {" +
-                "       Events.fire('text-recipient', e.detail);" +
-                "   }" +
                 "}, false);" + (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK) ? "document.getElementById('theme').hidden = true;" : "");
     }
 

--- a/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
+++ b/app/src/main/java/com/fmsys/snapdrop/JavaScriptInterface.java
@@ -244,7 +244,7 @@ public class JavaScriptInterface {
                 "            };" +
             
                 //change tweet link
-                "document.querySelector('.icon-button[title~='Tweet']').href = 'https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20An%20Android%20client%20for https://snapdrop.net%20by%20@robin_linus%20&';" +
+                "document.querySelector('.icon-button[title~=\"Tweet\"]').href = 'https://twitter.com/intent/tweet?text=@SnapdropAndroid%20-%20An%20Android%20client%20for https://snapdrop.net%20by%20@robin_linus%20&';" +
             
                 //add settings icon-button
                 "let settingsIconButton = document.createElement('a');" +
@@ -262,7 +262,7 @@ public class JavaScriptInterface {
                 "settingsSvg.appendChild(settingsPath);" +
                 "settingsIconButton.appendChild(settingsSvg);" +
 
-                "let aboutIconButton = document.querySelector('.icon-button[href='#about']');" +
+                "let aboutIconButton = document.querySelector('.icon-button[href=\"#about\"]');" +
                 "aboutIconButton.parentElement.insertBefore(settingsIconButton, aboutIconButton.nextSibling);" +
             
                 //change ServerConnection.send(message) to connect to JavaScriptInterface

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -75,7 +75,7 @@ public class MainActivity extends Activity {
     public boolean onlyText = false;
     public List<Pair<String, String>> downloadFilesList = new ArrayList<>(); // name - size
     public boolean transfer = false;
-    private boolean forceRefresh = false;
+    public boolean forceRefresh = false;
 
     public Intent uploadIntent = null;
 

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -289,13 +289,13 @@ public class MainActivity extends Activity {
         return System.currentTimeMillis() - prefs.getLong(getString(R.string.pref_last_server_connection), 0) > 1000 * 60 * 3;
     }
 
-    /*@Override
+    @Override
     public void onResume() {
         super.onResume();
         if (!onlinePastThreeMin()) {
             refreshWebsite();
         }
-    }*/
+    }
 
     @Override
     protected void onDestroy() {

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -148,7 +148,7 @@ public class MainActivity extends Activity {
         cookieManager.setAcceptThirdPartyCookies(webView, true);
 
         // check if the last server connection was in the past 3 minutes - if yes we don't create a new UUID as the "old peer" might still be visible
-        if (onlineLastThreeMin()) {
+        if (onlinePastThreeMin()) {
             WebStorage.getInstance().deleteAllData();
 
             cookieManager.setCookie("https://snapdrop.net/",
@@ -285,14 +285,14 @@ public class MainActivity extends Activity {
         }
     }
     
-    private boolean onlineLastThreeMin() {
+    private boolean onlinePastThreeMin() {
         return System.currentTimeMillis() - prefs.getLong(getString(R.string.pref_last_server_connection), 0) > 1000 * 60 * 3;
     }
 
     /*@Override
     public void onResume() {
         super.onResume();
-        if (!onlineLastThreeMin()) {
+        if (!onlinePastThreeMin()) {
             refreshWebsite();
         }
     }*/

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -58,8 +58,8 @@ public class MainActivity extends Activity {
     private static final int LAUNCH_SETTINGS_ACTIVITY = 12;
     public static final int REQUEST_SELECT_FILE = 100;
 
-    private static final String baseURL = "https://fm-sys.github.io/snapdrop/client/";
-    //private static final String baseURL = "https://snapdrop.net/";
+    //private static final String baseURL = "https://fm-sys.github.io/snapdrop/client/";
+    private static final String baseURL = "https://snapdrop.net/";
 
     public WebView webView;
     public SharedPreferences prefs;

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -292,7 +292,7 @@ public class MainActivity extends Activity {
     @Override
     public void onResume() {
         super.onResume();
-        if (!onlinePastThreeMin()) {
+        if (onlinePastThreeMin()) {
             refreshWebsite();
         }
     }

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -285,11 +285,11 @@ public class MainActivity extends Activity {
         }
     }
 
-    @Override
+    /*@Override
     public void onResume() {
         super.onResume();
         refreshWebsite();
-    }
+    }*/
 
     @Override
     protected void onDestroy() {

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -148,7 +148,7 @@ public class MainActivity extends Activity {
         cookieManager.setAcceptThirdPartyCookies(webView, true);
 
         // check if the last server connection was in the past 3 minutes - if yes we don't create a new UUID as the "old peer" might still be visible
-        if (System.currentTimeMillis() - prefs.getLong(getString(R.string.pref_last_server_connection), 0) > 1000 * 60 * 3) {
+        if (onlineLastThreeMin()) {
             WebStorage.getInstance().deleteAllData();
 
             cookieManager.setCookie("https://snapdrop.net/",
@@ -284,11 +284,17 @@ public class MainActivity extends Activity {
             super.onBackPressed();
         }
     }
+    
+    private boolean onlineLastThreeMin() {
+        return System.currentTimeMillis() - prefs.getLong(getString(R.string.pref_last_server_connection), 0) > 1000 * 60 * 3;
+    }
 
     /*@Override
     public void onResume() {
         super.onResume();
-        refreshWebsite();
+        if (!onlineLastThreeMin()) {
+            refreshWebsite();
+        }
     }*/
 
     @Override


### PR DESCRIPTION
Integrate https://github.com/fm-sys/snapdrop in the app

so i added
- copy to JSI
- change tweet
- added settings button
- handle serverconnection-active/updateLastOnlineTime 
- handle recipient-shortclicked/shouldOpenSendTextDialog
- remove donations button
- remove weird sound (safari hack)

please tell me if there are other important changes (what about `getVersionId`?)

Tested in Firefox with Tampermonkey. it should be executed at `document-idle` (should be fine with `onPageFinished`)

Also added onResume `refreshWebsite` behaviour guarded by `onlinePastThreeMin` to prevent refreshing to soon or while picking a file