### PR TITLE
Deep Link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,15 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="*/*" />
             </intent-filter>
+                <intent-filter android:label="@string/app_name" >
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="snapdrop.net" />
+            </intent-filter>
 
             <meta-data
                 android:name="android.app.shortcuts"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,9 +47,8 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:scheme="https"
-                    android:host="snapdrop.net" />
+                <data android:scheme="http" android:host="snapdrop.net" />
+                <data android:scheme="https" android:host="snapdrop.net" />
             </intent-filter>
 
             <meta-data


### PR DESCRIPTION
handle snapdrop.net links (-> open app)
might prevent a second instance getting started in the browser (works when link is clicked in any app other than browser)