### PR TITLE
added baseurl preference

### DIFF
--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -462,6 +462,10 @@ public class MainActivity extends Activity {
 
         @Override
         public void onReceivedError(final WebView view, final WebResourceRequest request, final WebResourceError error) {
+            //reset baseURL if invalid
+            prefs.edit().remove(getString(R.string.pref_baseurl)).apply();
+            baseURL = getString(R.string.baseURL);
+            
             showScreenNoConnection();
         }
 

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -58,8 +58,7 @@ public class MainActivity extends Activity {
     private static final int LAUNCH_SETTINGS_ACTIVITY = 12;
     public static final int REQUEST_SELECT_FILE = 100;
 
-    //private static final String baseURL = "https://fm-sys.github.io/snapdrop/client/";
-    private static final String baseURL = "https://snapdrop.net/";
+    private String baseURL;
 
     public WebView webView;
     public SharedPreferences prefs;
@@ -105,6 +104,8 @@ public class MainActivity extends Activity {
         this.requestWindowFeature(Window.FEATURE_NO_TITLE);
 
         prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        
+        baseURL = prefs.getString(getString(R.string.pref_baseurl), getString(R.string.baseURL));
 
         if (prefs.getBoolean(getString(R.string.pref_switch_keep_on), false)) {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);

--- a/app/src/main/java/com/fmsys/snapdrop/SettingsFragment.java
+++ b/app/src/main/java/com/fmsys/snapdrop/SettingsFragment.java
@@ -43,6 +43,13 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             builder.create().show();
             return true;
         });
+        
+        final Preference baseUrlPref = findPreference(getString(R.string.pref_baseurl));
+        baseUrlPref.setSummary(PreferenceManager.getDefaultSharedPreferences(getContext()).getString(baseUrlPref.getKey(),getString(R.string.baseURL)));
+        baseUrlPref.setOnPreferenceChangeListener((preference, newValue) -> {
+            baseUrlPref.setSummary(newValue.toString());
+            return true;
+        });
 
         final Preference themePref = findPreference(getString(R.string.pref_theme_setting));
             themePref.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {

--- a/app/src/main/java/com/fmsys/snapdrop/SettingsFragment.java
+++ b/app/src/main/java/com/fmsys/snapdrop/SettingsFragment.java
@@ -45,7 +45,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         });
         
         final Preference baseUrlPref = findPreference(getString(R.string.pref_baseurl));
-        baseUrlPref.setSummary(PreferenceManager.getDefaultSharedPreferences(getContext()).getString(baseUrlPref.getKey(),getString(R.string.baseURL)));
+        baseUrlPref.setSummary(PreferenceManager.getDefaultSharedPreferences(getContext()).getString(baseUrlPref.getKey(), getString(R.string.baseURL)));
         baseUrlPref.setOnPreferenceChangeListener((preference, newValue) -> {
             baseUrlPref.setSummary(newValue.toString());
             return true;

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -4,6 +4,7 @@
     <string name="pref_last_server_connection" translatable="false">last_server_connection</string>
     <string name="pref_device_name" translatable="false">device_name</string>
     <string name="pref_first_use" translatable="false">first_use</string>
+    <string name="pref_baseurl" translatable="false">baseurl</string>
 
     <!-- Theme settings -->
     <string name="pref_theme_setting" translatable="false">theme_setting</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
         <item>Light</item>
         <item>Dark</item>
     </string-array>
+    <string name="baseurl_title">Base URL</string>
 
     <!-- File sharing -->
     <string name="intent_file">A file is selected for sharing</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,4 +51,7 @@
     <string name="error_filechooser">Cannot open file chooser</string>
     <string name="error_network">Please verify that you are connected with a WiFi network</string>
     <string name="ignore_error_network">Let me in anyway</string>
+    
+    <!-- baseURL -->
+    <string name="baseURL" translatable="false">https://snapdrop.net/</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -25,6 +25,12 @@
             android:title="@string/settings_theme_title"
             android:summary="%s"
             app:iconSpaceReserved="false" />
+        <EditTextPreference
+            android:defaultValue="@string/baseURL"
+            android:key="@string/pref_baseurl"
+            android:title="@string/baseurl_title"
+            android:summary="%s"
+            app:iconSpaceReserved="false" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
 Fixes https://github.com/fm-sys/snapdrop-android/issues/44

if the url is invalid it can get reseted in `onReceivedError`, this might not work, which then would require a reinstall