### PR TITLE
Update Simple Storage version to 0.9.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
-    implementation 'com.anggrayudi:storage:0.5.3'
+    implementation 'com.anggrayudi:storage:0.9.0'
 
 }
 


### PR DESCRIPTION
`DocumentFileUtils.moveFileToDownloadMedia()` can move files into `Download` regardless of API levels.

For more info: https://github.com/anggrayudi/SimpleStorage/releases