### PR TITLE
Fix display height and support additional functions by bringing out buttons

### DIFF
--- a/app/src/main/assets/init.js
+++ b/app/src/main/assets/init.js
@@ -80,7 +80,8 @@ try {
 //move about background to the left side (for better opening animation)
 try {
     let aboutBackground = document.querySelector('#about>x-background');
-    aboutBackground.style.left = 'calc(32px - 200px)';
+    aboutBackground.style.top = 'calc(-32px - 250px)';
+    aboutBackground.style.left = 'calc(32px - 250px)';
     aboutBackground.style.right = null;
 } catch (e) {
     console.error(e);
@@ -146,7 +147,10 @@ try {
 //show localized display name
 try {
     let localizeDisplayName = function(str){
-        document.getElementById('displayName').textContent = SnapdropAndroid.getYouAreKnownAsTranslationString(str);
+        const displayNameNode = document.getElementById('displayName');
+        if (displayNameNode.textContent.substring(0, 17) === "You are known as ") {
+            displayNameNode.textContent = SnapdropAndroid.getYouAreKnownAsTranslationString(str);
+        }
     };
 
     window.addEventListener('display-name', e => window.setTimeout(_ => localizeDisplayName(e.detail.message.displayName), 100), false);
@@ -162,3 +166,11 @@ try {
 window.addEventListener('file-received', e => {
     SnapdropAndroid.saveDownloadFileName(e.detail.name, e.detail.size);
 }, false);
+
+try {
+    document.querySelector('#theme').style.display = "none";
+    document.querySelector('.icon-button[href="#about"]').style.display = "none";
+    document.querySelector('.icon-button[href="#"]').style.display = "none";
+} catch (e) {
+    console.error(e);
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,6 +17,7 @@
             android:id="@+id/webview"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
+            android:layout_marginTop="?attr/actionBarSize"
             android:scrollbars="none"
             android:textCursorDrawable="@color/colorAccent" />
 


### PR DESCRIPTION
This is needed to support PairDrops pairing feature but also fixes #257 

I'm not sure about the translation though. To ensure the app does not break functionalities by overwriting html contents, maybe instead of checking whether a string is an original Snapdrop string translation via injection could also be optionally switched off completely via settings.