### PR TITLE
Fixes issue #211 - EXIF data stripped while sharing pictures

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 
@@ -20,7 +21,8 @@
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
-    <uses-feature android:name="android.software.leanback"
+    <uses-feature
+        android:name="android.software.leanback"
         android:required="false" />
 
 
@@ -34,9 +36,9 @@
     <application
         android:name=".SnapdropApplication"
         android:allowBackup="false"
+        android:banner="@drawable/tv_banner"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
-        android:banner="@drawable/tv_banner"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -83,6 +83,7 @@ import java.util.concurrent.Executors;
 
 public class MainActivity extends AppCompatActivity {
     private static final int MY_PERMISSIONS_WRITE_EXTERNAL_STORAGE = 12321;
+    private static final int MY_PERMISSIONS_ACCESS_MEDIA_LOCATION = 1315;
     private static final int LAUNCH_SETTINGS_ACTIVITY = 12;
     public static final int REQUEST_SELECT_FILE = 100;
 
@@ -227,6 +228,10 @@ public class MainActivity extends AppCompatActivity {
         if ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q)
                 && (ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED)) {
             requestPermissions(new String[]{android.Manifest.permission.WRITE_EXTERNAL_STORAGE}, MY_PERMISSIONS_WRITE_EXTERNAL_STORAGE);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            requestPermissions(new String[]{Manifest.permission.ACCESS_MEDIA_LOCATION}, MY_PERMISSIONS_ACCESS_MEDIA_LOCATION);
         }
 
         binding.pullToRefresh.setOnRefreshListener(() -> refreshWebsite(true));


### PR DESCRIPTION
**Device Info:**

Brand: Realme
Model: Narzo 30 5G
API Level: Android 13 (API level 33)

**Changes Made:**

1. Added ACCESS_MEDIA_LOCATION permission to the manifest
2. Requested permission in MainActivity

**Resources:**

[Android documentation (media location permission)](https://developer.android.com/training/data-storage/shared/media#media-location-permission)


The EXIF data was stripped due to privacy features implemented in the Android OS. Android devices targeting  Android 10 (API level 29) and above must declare the [ACCESS_MEDIA_LOCATION](https://developer.android.com/reference/android/Manifest.permission#ACCESS_MEDIA_LOCATION) permission and request it during runtime.

As the permission is classified as DANGEROUS, explicit user concern is required to obtain images without redacting EXIF data.



![image](https://user-images.githubusercontent.com/112970189/233335513-0055304c-d7dc-43a4-962a-c49b9d790339.png)
Permission is requested when the user enters MainActivity


The image EXIF data is retained when shared from within the app and Intent (Share with - Snapdrop)