### PR TITLE
Made connectivity card message optional

### DIFF
--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -115,10 +115,10 @@ public class MainActivity extends AppCompatActivity {
             final boolean wifiAvailable = NetworkUtils.isWiFi(intent.getParcelableExtra(WifiManager.EXTRA_NETWORK_INFO));
             prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
-            boolean show = prefs.getBoolean(getString(R.string.pref_show_connectivity_card), true);
-            if(show){
+            final boolean show = prefs.getBoolean(getString(R.string.pref_show_connectivity_card), true);
+            if (show) {
                 binding.connectivityCard.setVisibility(wifiAvailable ? View.GONE : View.VISIBLE);
-            }else{
+            } else {
                 binding.connectivityCard.setVisibility(View.GONE);
             }
 

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -113,7 +113,7 @@ public class MainActivity extends AppCompatActivity {
         public void onReceive(final Context context, final Intent intent) {
             final boolean wasMobileData = binding.connectivityCard.getVisibility() == View.VISIBLE;
             final boolean wifiAvailable = NetworkUtils.isWiFi(intent.getParcelableExtra(WifiManager.EXTRA_NETWORK_INFO));
-            binding.connectivityCard.setVisibility(wifiAvailable ? View.GONE : View.VISIBLE);
+            binding.connectivityCard.setVisibility(View.GONE);
             if (state.isCurrentlyOffline() || wasMobileData) {
                 if (wifiAvailable) {
                     refreshWebsite();

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -113,7 +113,15 @@ public class MainActivity extends AppCompatActivity {
         public void onReceive(final Context context, final Intent intent) {
             final boolean wasMobileData = binding.connectivityCard.getVisibility() == View.VISIBLE;
             final boolean wifiAvailable = NetworkUtils.isWiFi(intent.getParcelableExtra(WifiManager.EXTRA_NETWORK_INFO));
-            binding.connectivityCard.setVisibility(View.GONE);
+            prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+            boolean show = prefs.getBoolean(getString(R.string.pref_show_connectivity_card), true);
+            if(show){
+                binding.connectivityCard.setVisibility(wifiAvailable ? View.GONE : View.VISIBLE);
+            }else{
+                binding.connectivityCard.setVisibility(View.GONE);
+            }
+
             if (state.isCurrentlyOffline() || wasMobileData) {
                 if (wifiAvailable) {
                     refreshWebsite();

--- a/app/src/main/java/com/fmsys/snapdrop/SettingsFragment.java
+++ b/app/src/main/java/com/fmsys/snapdrop/SettingsFragment.java
@@ -146,18 +146,6 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             });
         }
 
-        final Preference showConnectivityCardPref = findPreference(getString(R.string.pref_show_connectivity_card));
-
-            showConnectivityCardPref.setVisible(true);
-            showConnectivityCardPref.setOnPreferenceChangeListener((pref, newValue) -> {
-
-                PreferenceManager.getDefaultSharedPreferences(getContext()).edit().putBoolean(showConnectivityCardPref.getKey(), (boolean) newValue).apply();
-                return true;
-            });
-
-
-
-
         final Preference deviceNamePref = findPreference(getString(R.string.pref_device_name));
         deviceNamePref.setOnPreferenceClickListener(pref -> showEditTextPreferenceWithResetPossibility(pref, "Android ", "", null, newValue -> updateDeviceNameSummary(deviceNamePref)));
         updateDeviceNameSummary(deviceNamePref);

--- a/app/src/main/java/com/fmsys/snapdrop/SettingsFragment.java
+++ b/app/src/main/java/com/fmsys/snapdrop/SettingsFragment.java
@@ -146,6 +146,18 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             });
         }
 
+        final Preference showConnectivityCardPref = findPreference(getString(R.string.pref_show_connectivity_card));
+
+            showConnectivityCardPref.setVisible(true);
+            showConnectivityCardPref.setOnPreferenceChangeListener((pref, newValue) -> {
+
+                PreferenceManager.getDefaultSharedPreferences(getContext()).edit().putBoolean(showConnectivityCardPref.getKey(), (boolean) newValue).apply();
+                return true;
+            });
+
+
+
+
         final Preference deviceNamePref = findPreference(getString(R.string.pref_device_name));
         deviceNamePref.setOnPreferenceClickListener(pref -> showEditTextPreferenceWithResetPossibility(pref, "Android ", "", null, newValue -> updateDeviceNameSummary(deviceNamePref)));
         updateDeviceNameSummary(deviceNamePref);

--- a/app/src/main/res/drawable/pref_connectivity_card.xml
+++ b/app/src/main/res/drawable/pref_connectivity_card.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="960" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M261,638q12,0 21,-9t9,-21q0,-12 -9,-21t-21,-9q-12,0 -21,9t-9,21q0,12 9,21t21,9ZM231,508h60v-191h-60v191ZM410,588h319v-60L410,528v60ZM410,417h319v-60L410,357v60ZM132,800q-24,0 -42,-18t-18,-42v-520q0,-24 18,-42t42,-18h696q24,0 42,18t18,42v520q0,24 -18,42t-42,18L132,800ZM132,740h696v-520L132,220v520ZM132,740v-520,520Z"/>
+</vector>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="pref_switch_keep_on" translatable="false">keep_screen_on</string>
     <string name="pref_floating_text_selection" translatable="false">floating_text_selection</string>
+    <string name="pref_show_connectivity_card" translatable="false">show_connectivity_card</string>
     <string name="pref_device_name" translatable="false">device_name</string>
     <string name="pref_first_use" translatable="false">first_use</string>
     <string name="pref_baseurl" translatable="false">baseurl</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,8 +54,8 @@
     <string name="keep_on_title">Keep screen on while transferring</string>
     <string name="floating_text_selection_title">Floating text selection</string>
     <string name="floating_text_selection_summary">When selecting text in other apps, an option \"Send with Snapdrop\" will be shown</string>
-    <string name="show_connectivity_card_title">Display connectivity card</string>
-    <string name="show_connectivity_card_summary"> Card to notify you that you need to pair or connect to the same wifi</string>
+    <string name="show_connectivity_card_title">Display connectivity warning</string>
+    <string name="show_connectivity_card_summary"> Show a warning when you are not connected with a WiFi network</string>
     <string name="floating_text_selection_activity_label">Send with Snapdrop</string>
     <string name="permission_not_granted">please grant the necessary permission</string>
     <string name="permission_not_granted_fallback">please grant the necessary permission manually</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="keep_on_title">Keep screen on while transferring</string>
     <string name="floating_text_selection_title">Floating text selection</string>
     <string name="floating_text_selection_summary">When selecting text in other apps, an option \"Send with Snapdrop\" will be shown</string>
-    <string name="show_connectivity_card_title">Display connectivity warning</string>
+    <string name="show_connectivity_card_title">Connectivity warning</string>
     <string name="show_connectivity_card_summary"> Show a warning when you are not connected with a WiFi network</string>
     <string name="floating_text_selection_activity_label">Send with Snapdrop</string>
     <string name="permission_not_granted">please grant the necessary permission</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,8 @@
     <string name="keep_on_title">Keep screen on while transferring</string>
     <string name="floating_text_selection_title">Floating text selection</string>
     <string name="floating_text_selection_summary">When selecting text in other apps, an option \"Send with Snapdrop\" will be shown</string>
+    <string name="show_connectivity_card_title">Display connectivity card</string>
+    <string name="show_connectivity_card_summary"> Card to notify you that you need to pair or connect to the same wifi</string>
     <string name="floating_text_selection_activity_label">Send with Snapdrop</string>
     <string name="permission_not_granted">please grant the necessary permission</string>
     <string name="permission_not_granted_fallback">please grant the necessary permission manually</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -18,6 +18,7 @@
             android:title="@string/keep_on_title" />
         <SwitchPreference
             android:defaultValue="true"
+            android:icon="@drawable/pref_connectivity_card"
             android:key="@string/pref_show_connectivity_card"
             android:summary="@string/show_connectivity_card_summary"
             android:title="@string/show_connectivity_card_title" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -17,6 +17,11 @@
             android:summary="@string/keep_on_summary"
             android:title="@string/keep_on_title" />
         <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/pref_show_connectivity_card"
+            android:summary="@string/show_connectivity_card_summary"
+            android:title="@string/show_connectivity_card_title" />
+        <SwitchPreference
             android:defaultValue="false"
             android:icon="@drawable/pref_floatingtext"
             android:key="@string/pref_floating_text_selection"


### PR DESCRIPTION
## Made connectivity card message optional

<img src="https://github.com/fm-sys/snapdrop-android/assets/59334044/e5749cad-fd7a-4d59-9a5a-e07b141b2b98" width="auto" height="300">
<img src="https://github.com/fm-sys/snapdrop-android/assets/59334044/ac2f1063-4058-4154-b961-a8e0f6b32403" width="auto" height="300">
<img src="https://github.com/fm-sys/snapdrop-android/assets/59334044/bcd2135a-f028-4bed-a1d3-5647bb0ad31b" width="auto" height="300">
<img src="https://github.com/fm-sys/snapdrop-android/assets/59334044/ce0794f4-4715-4f1b-9e38-efd51e1e19cd" width="auto" height="300">

The connectivity card shows every time you are on a mobile network. This would be useful for first time users but using the app often just becomes an annoyance. You already know how it works, why should you be stuck with an immutable notification. This PR solves the problem by adding an option in the settings menu to disable the connectivity card from showing. 

