### PR TITLE
Prevent localization by app if localization is built in

### DIFF
--- a/app/src/main/assets/init.js
+++ b/app/src/main/assets/init.js
@@ -157,19 +157,23 @@ try {
 
 //show localized display name
 try {
-    let localizeDisplayName = function(str){
-        const displayNameNode = document.getElementById('displayName');
-        // don't change it e.g. for pairdrop.net
-        if (displayNameNode.textContent.substring(0, 17) === "You are known as ") {
-            displayNameNode.textContent = SnapdropAndroid.getYouAreKnownAsTranslationString(str);
+    const localizationBuiltIn = !!document.getElementById('language-selector');
+
+    if (!localizationBuiltIn) {
+        let localizeDisplayName = function(str){
+            const displayNameNode = document.getElementById('displayName');
+            // don't change it e.g. for pairdrop.net
+            if (displayNameNode.textContent.substring(0, 17) === "You are known as ") {
+                displayNameNode.textContent = SnapdropAndroid.getYouAreKnownAsTranslationString(str);
+            }
+        };
+
+        window.addEventListener('display-name', e => window.setTimeout(_ => localizeDisplayName(e.detail.message.displayName), 100), false);
+
+        let currentText = document.getElementById('displayName').textContent;
+        if(currentText.startsWith("You are known as ")){
+            localizeDisplayName(currentText.split("You are known as ")[1]);
         }
-    };
-
-    window.addEventListener('display-name', e => window.setTimeout(_ => localizeDisplayName(e.detail.message.displayName), 100), false);
-
-    let currentText = document.getElementById('displayName').textContent;
-    if(currentText.startsWith("You are known as ")){
-        localizeDisplayName(currentText.split("You are known as ")[1]);
     }
 } catch (e) {
     console.error(e);

--- a/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
+++ b/app/src/main/java/com/fmsys/snapdrop/MainActivity.java
@@ -578,7 +578,7 @@ public class MainActivity extends AppCompatActivity {
             binding.webview.evaluateJavascript(JavaScriptInterface.getAssetsJS(MainActivity.this, "init.js"),
                     returnValue -> binding.loadAnimator.animate().alpha(0).withEndAction(() -> binding.webview.animate().alpha(1).start()));
             binding.webview.evaluateJavascript(JavaScriptInterface.getSendTextDialogWithPreInsertedString(getTextFromUploadIntent()), null);
-            WebsiteLocalizer.localize(binding.webview);
+            WebsiteLocalizer.localizeIfNotBuiltIn(binding.webview);
             Log.w("WebView", "init end.");
         }
 

--- a/app/src/main/java/com/fmsys/snapdrop/WebsiteLocalizer.java
+++ b/app/src/main/java/com/fmsys/snapdrop/WebsiteLocalizer.java
@@ -41,6 +41,15 @@ public class WebsiteLocalizer {
         // no instances
     }
 
+    public static void localizeIfNotBuiltIn(final WebView webView) {
+        webView.evaluateJavascript("(function() { return !!document.getElementById('language-selector'); })();", localizationBuiltIn -> {
+            if (localizationBuiltIn.equals("false")) {
+                //Localization is not built into instance. Localize via snapdrop-android.
+                localize(webView);
+            }
+        });
+    }
+
     public static void localize(final WebView webView) {
         for (TranslationElement element : TranslationElement.values()) {
             webView.evaluateJavascript(getTranslationJS(element, webView.getContext()), null);


### PR DESCRIPTION
Prevent localization by app if localization is built in on the current instance. Evaluate by checking if language-selector exists.

Fixes #334 